### PR TITLE
Functions which read data now return the tag, even it it's an unknown record.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ install: compile
 
 uninstall:
 	cd $(BUILDDIR) && meson --internal uninstall
+
+test:
+	meson test -C $(BUILDDIR) --suite fcio

--- a/meson.build
+++ b/meson.build
@@ -19,5 +19,7 @@ subdir('src')
 
 fcio_dep = declare_dependency(include_directories : fcio_inc, link_with : fcio_lib, sources : fcio_sources, dependencies : [tmio_dep])
 
+subdir('tests')
+
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(fcio_lib)

--- a/src/fcio.c
+++ b/src/fcio.c
@@ -1394,7 +1394,7 @@ static int get_next_record(FCIOStateReader *reader, int timeout)
     fprintf(stderr, "get_next_record: got tag %d \n", tag);
 
   if (tag <= 0)
-    return 0;
+    return tag;
 
   fcio_config *config = reader->nconfigs ? &reader->configs[(reader->cur_config + reader->max_states - 1) % reader->max_states] : NULL;
   fcio_event *event = reader->nevents ? &reader->events[(reader->cur_event + reader->max_states - 1) % reader->max_states] : NULL;
@@ -1473,7 +1473,6 @@ static int get_next_record(FCIOStateReader *reader, int timeout)
   // Advance state buffer
   if (tag_selected(reader, tag)) {
     reader->cur_state = (reader->cur_state + 1) % reader->max_states;
-    reader->states[reader->cur_state].last_tag = 0;
     reader->nrecords++;
   }
 

--- a/src/fcio.c
+++ b/src/fcio.c
@@ -432,6 +432,23 @@ returns 1 on success or 0 on error
   return 1;
 }
 
+
+/*=== Function ===================================================*/
+
+FCIOStream FCIOStreamHandle(FCIOData *x)
+
+/*--- Description ------------------------------------------------//
+
+Returns the internal FCIOStream object on success or NULL on error.
+
+//----------------------------------------------------------------*/
+{
+  FCIOStream xio=x->ptmio;
+  if(xio==NULL) return NULL;
+  if(debug>2) fprintf(stderr,"FCIOStream/DEBUG: return stream pointer.\n");
+  return xio;
+}
+
 /*=== Function ===================================================*/
 
 int FCIOPutConfig(FCIOStream output, FCIOData *input)

--- a/src/fcio.h
+++ b/src/fcio.h
@@ -267,6 +267,8 @@ int FCIORead(FCIOStream x, int size, void *data)
 ;
 int FCIOWaitMessage(FCIOStream x, int tmo)
 ;
+FCIOStream FCIOStreamHandle(FCIOData *x)
+;
 
 typedef struct {
   fcio_config *config;

--- a/tests/fcio_test_unknown_tags.c
+++ b/tests/fcio_test_unknown_tags.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include <fcio.h>
+
+#define TESTTAG 31
+#define TESTCONTENT 10
+#define FCIODEBUG 10
+
+/* 
+  This test checks if unkown tags are passed to the user by GetRecord and GetNextState without reading any data.
+*/
+
+int main(int argc, char* argv[])
+{
+  FCIODebug(FCIODEBUG);
+
+  /* write test file*/
+  FCIOStream stream = FCIOConnect(argv[1], 'w', 0, 0);
+  FCIOWriteMessage(stream, TESTTAG);
+  FCIOWriteInt(stream, TESTCONTENT);
+  FCIODisconnect(stream);
+
+  /* read using GetRecord */
+  FCIOData* input = FCIOOpen(argv[1], 0, 0);
+  int tag = FCIOGetRecord(input);
+  assert(tag == TESTTAG);
+  int content = 0;
+  FCIOReadInt(input->ptmio, content);
+  FCIOClose(input);
+  assert(content == TESTCONTENT);
+
+  /* read using StateReader */
+  FCIOStateReader* reader = FCIOCreateStateReader(argv[1], 0, 0, 0);
+  int timedout = -1;
+  FCIOState* state = FCIOGetNextState(reader, &timedout);
+  FCIODestroyStateReader(reader);
+  assert(state->last_tag == TESTTAG);
+  assert(timedout == 0);
+
+  /* read using StateReader, but deselected */
+  reader = FCIOCreateStateReader(argv[1], 0, 0, 0);
+  FCIODeselectStateTag(reader, TESTTAG);
+  state = FCIOGetNextState(reader, &timedout);
+  FCIODestroyStateReader(reader);
+  assert(state == NULL);
+  assert(timedout == 2);
+
+  return 0;
+
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,3 @@
+fcio_test_unknown_tags = executable('fcio_test_unknown_tags', 'fcio_test_unknown_tags.c', dependencies : [fcio_dep])
+
+test('fcio_test_unknown_tags', fcio_test_unknown_tags, is_parallel : true, args : ['fcio_test_unknown_tags.dat'])


### PR DESCRIPTION
GetNextState now returns the tag even it it's not known, without advancing the current state.

Enables external reading of the stream (by a library user) if an unkown tag is found.
Those tags won't be present in the state history.

If an unkown tag is deselected, it will not be returned, therefore allows to silence such records.

The zeroing of the next state `last_tag` field is removed, such that the `last_tag` update is not overwritten if `buffer_depth == 0`.
Does not break library behaviour, as any successful tag read (`tag > 0`) updates the `last_tag` field anyway.