### PR TITLE
Add fcio_utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILDDIR:=build
 
-.PHONY: setup compile install uninstall clean
+.PHONY: setup compile install uninstall clean debug release
 
 all: compile
 
@@ -15,6 +15,10 @@ compile: $(BUILDDIR)
 
 local: $(BUILDDIR)
 	meson configure -Dprefix=${HOME}/.local $(BUILDDIR)
+
+debug release: $(BUILDDIR)
+	meson configure --buildtype $@ $(BUILDDIR)
+	$(MAKE) compile
 
 install: compile
 	meson install -C $(BUILDDIR)

--- a/meson.build
+++ b/meson.build
@@ -13,14 +13,10 @@ project('fcio', 'c',
 
 tmio_dep = dependency('tmio', fallback : ['tmio', 'tmio_dep'])
 
-fcio_inc= include_directories('src')
+
 
 subdir('src')
-
-fcio_dep = declare_dependency(include_directories : fcio_inc, link_with : fcio_lib, sources : fcio_sources, dependencies : [tmio_dep])
-
 subdir('tests')
-
 subdir('examples')
 
 pkg_mod = import('pkgconfig')

--- a/src/fcio_utils.c
+++ b/src/fcio_utils.c
@@ -14,40 +14,40 @@ size_t FCIOWrittenBytes(FCIOStream stream)
   return new;
 }
 
-FCIORecordSizes FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes sizes)
+void FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes* sizes)
 {
+  if (!data || !sizes)
+    return;
   const char* null_device = "file:///dev/null";
 
   FCIOWrittenBytes(NULL);
   FCIOStream stream = FCIOConnect(null_device, 'w', 0, 0);
-  sizes.protocol = FCIOWrittenBytes(stream);
+  sizes->protocol = FCIOWrittenBytes(stream);
 
   size_t current_size = 0;
   int rc = 0;
 
   rc = FCIOPutConfig(stream, data);
   if ((current_size = FCIOWrittenBytes(stream)) && !rc)
-    sizes.config = current_size;
+    sizes->config = current_size;
 
   rc = FCIOPutEvent(stream, data);
   if ((current_size = FCIOWrittenBytes(stream)) && !rc)
-    sizes.event = current_size;
+    sizes->event = current_size;
 
   rc = FCIOPutStatus(stream, data);
   if ((current_size = FCIOWrittenBytes(stream)) && !rc)
-    sizes.status = current_size;
+    sizes->status = current_size;
 
   rc = FCIOPutEventHeader(stream, data);
   if ((current_size = FCIOWrittenBytes(stream)) && !rc)
-    sizes.eventheader = current_size;
+    sizes->eventheader = current_size;
 
   rc = FCIOPutSparseEvent(stream, data);
   if ((current_size = FCIOWrittenBytes(stream)) && !rc)
-    sizes.sparseevent = current_size;
+    sizes->sparseevent = current_size;
 
   FCIODisconnect(stream);
-
-  return sizes;
 }
 
 
@@ -116,16 +116,17 @@ static inline size_t status_size(const fcio_status* status)
 }
 
 
-FCIORecordSizes FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes sizes)
+void FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes* sizes)
 {
+  if (!data || !sizes)
+    return;
+
   const size_t frame_header = sizeof(int);
 
-  sizes.protocol = TMIO_PROTOCOL_SIZE + frame_header;
-  sizes.config = config_size(&data->config);
-  sizes.event = event_size(FCIOEvent, &data->event, &data->config);
-  sizes.status = status_size(&data->status);
-  sizes.eventheader = event_size(FCIOEventHeader, &data->event, &data->config);
-  sizes.sparseevent = event_size(FCIOSparseEvent, &data->event, &data->config);
-
-  return sizes;
+  sizes->protocol = TMIO_PROTOCOL_SIZE + frame_header;
+  sizes->config = config_size(&data->config);
+  sizes->event = event_size(FCIOEvent, &data->event, &data->config);
+  sizes->status = status_size(&data->status);
+  sizes->eventheader = event_size(FCIOEventHeader, &data->event, &data->config);
+  sizes->sparseevent = event_size(FCIOSparseEvent, &data->event, &data->config);
 }

--- a/src/fcio_utils.c
+++ b/src/fcio_utils.c
@@ -1,6 +1,16 @@
 #include "fcio_utils.h"
 #include "fcio.h"
+
+#include <bufio.h>
 #include <tmio.h>
+
+int FCIOSetMemField(FCIOStream stream, char *mem_addr, size_t mem_size) {
+  if (!mem_addr)
+    return -1;
+  // bufio_set_mem_field check if the stream was opened using mem://
+  // returns 0 on success, 1 on error.
+  return bufio_set_mem_field(tmio_stream_handle(stream), mem_addr, mem_size);
+}
 
 size_t FCIOWrittenBytes(FCIOStream stream)
 {

--- a/src/fcio_utils.c
+++ b/src/fcio_utils.c
@@ -152,3 +152,21 @@ void FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes* sizes)
   sizes->eventheader = event_size(FCIOEventHeader, &data->event, &data->config);
   sizes->sparseevent = event_size(FCIOSparseEvent, &data->event, &data->config);
 }
+
+const char* FCIOTagStr(int tag)
+{
+  switch (tag) {
+    case FCIOConfig: return "FCIOConfig";
+    case FCIOCalib: return "FCIOCalib";
+    case FCIOEvent: return "FCIOEvent";
+    case FCIOStatus: return "FCIOStatus";
+    case FCIORecEvent: return "FCIORecEvent";
+    case FCIOSparseEvent: return "FCIOSparseEvent";
+    case FCIOEventHeader: return "FCIOEventHeader";
+    case FCIOFSPConfig: return "FCIOFSPConfig";
+    case FCIOFSPEvent: return "FCIOFSPEvent";
+    case FCIOFSPStatus: return "FCIOFSPStatus";
+    case 0: return "EOF";
+    default: return "ERROR";
+  }
+}

--- a/src/fcio_utils.c
+++ b/src/fcio_utils.c
@@ -187,3 +187,21 @@ void FCIOPrintRecordSizes(FCIORecordSizes sizes)
   fprintf(stderr, "..fspevent    %zu bytes\n", sizes.fspevent);
   fprintf(stderr, "..fspstatus   %zu bytes\n", sizes.fspstatus);
 }
+
+const char* FCIOTagStr(int tag)
+{
+  switch (tag) {
+    case FCIOConfig: return "FCIOConfig";
+    case FCIOCalib: return "FCIOCalib";
+    case FCIOEvent: return "FCIOEvent";
+    case FCIOStatus: return "FCIOStatus";
+    case FCIORecEvent: return "FCIORecEvent";
+    case FCIOSparseEvent: return "FCIOSparseEvent";
+    case FCIOEventHeader: return "FCIOEventHeader";
+    case FCIOFSPConfig: return "FCIOFSPConfig";
+    case FCIOFSPEvent: return "FCIOFSPEvent";
+    case FCIOFSPStatus: return "FCIOFSPStatus";
+    case 0: return "EOF";
+    default: return "ERROR";
+  }
+}

--- a/src/fcio_utils.c
+++ b/src/fcio_utils.c
@@ -1,0 +1,131 @@
+#include "fcio_utils.h"
+#include "fcio.h"
+#include <tmio.h>
+
+size_t FCIOWrittenBytes(FCIOStream stream)
+{
+  static size_t written = 0;
+  if (!stream)
+    return written = 0;
+  tmio_stream* tmio = (tmio_stream*)stream;
+
+  size_t new = tmio->byteswritten - written;
+  written = tmio->byteswritten;
+  return new;
+}
+
+FCIORecordSizes FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes sizes)
+{
+  const char* null_device = "file:///dev/null";
+
+  FCIOWrittenBytes(NULL);
+  FCIOStream stream = FCIOConnect(null_device, 'w', 0, 0);
+  sizes.protocol = FCIOWrittenBytes(stream);
+
+  size_t current_size = 0;
+  int rc = 0;
+
+  rc = FCIOPutConfig(stream, data);
+  if ((current_size = FCIOWrittenBytes(stream)) && !rc)
+    sizes.config = current_size;
+
+  rc = FCIOPutEvent(stream, data);
+  if ((current_size = FCIOWrittenBytes(stream)) && !rc)
+    sizes.event = current_size;
+
+  rc = FCIOPutStatus(stream, data);
+  if ((current_size = FCIOWrittenBytes(stream)) && !rc)
+    sizes.status = current_size;
+
+  rc = FCIOPutEventHeader(stream, data);
+  if ((current_size = FCIOWrittenBytes(stream)) && !rc)
+    sizes.eventheader = current_size;
+
+  rc = FCIOPutSparseEvent(stream, data);
+  if ((current_size = FCIOWrittenBytes(stream)) && !rc)
+    sizes.sparseevent = current_size;
+
+  FCIODisconnect(stream);
+
+  return sizes;
+}
+
+
+static inline size_t event_size(FCIOTag tag, const fcio_event* event, const fcio_config* config)
+{
+  const size_t frame_header = sizeof(int);
+  size_t total_size = 0;
+
+  total_size += frame_header; // tag_size
+  total_size += frame_header + sizeof(((fcio_event){0}).type); // type_size
+  total_size += frame_header + sizeof(((fcio_event){0}).pulser); // pulser_size
+  total_size += frame_header + sizeof(*((fcio_event){0}).timeoffset) * event->timeoffset_size; // timeoffset_size
+  total_size += frame_header + sizeof(*((fcio_event){0}).timestamp) * event->timestamp_size; // timestamp_size
+  total_size += frame_header + sizeof(*((fcio_event){0}).deadregion) * event->deadregion_size; // deadregion_size
+  switch (tag) {
+    case FCIOEvent:
+    total_size += frame_header + sizeof(*((fcio_event){0}).traces) * ((config->adcs+config->triggers) * (config->eventsamples+2)); // traces
+    break;
+    case FCIOSparseEvent:
+    total_size += frame_header + sizeof(((fcio_event){0}).num_traces); // num_traces
+    total_size += frame_header + sizeof(*((fcio_event){0}).trace_list) * event->num_traces; // trace_list
+    total_size += event->num_traces * (frame_header + (config->eventsamples+2) * sizeof(*((fcio_event){0}).traces)); // individual traces
+    break;
+    case FCIOEventHeader:
+    total_size += frame_header + sizeof(*((fcio_event){0}).trace_list) * event->num_traces; // trace_list
+    total_size += frame_header + sizeof(unsigned short) * event->num_traces * 2; // headerbuffer
+    break;
+    default:
+      return 0;
+  }
+  return total_size;
+}
+
+static inline size_t config_size(const fcio_config* config)
+{
+  const size_t frame_header = sizeof(int);
+  size_t total_size = 0;
+
+  total_size += frame_header; // tag_size
+  total_size += frame_header + sizeof(((fcio_config){0}).adcs);
+  total_size += frame_header + sizeof(((fcio_config){0}).triggers);
+  total_size += frame_header + sizeof(((fcio_config){0}).eventsamples);
+  total_size += frame_header + sizeof(((fcio_config){0}).blprecision);
+  total_size += frame_header + sizeof(((fcio_config){0}).sumlength);
+  total_size += frame_header + sizeof(((fcio_config){0}).adcbits);
+  total_size += frame_header + sizeof(((fcio_config){0}).mastercards);
+  total_size += frame_header + sizeof(((fcio_config){0}).triggercards);
+  total_size += frame_header + sizeof(((fcio_config){0}).adccards);
+  total_size += frame_header + sizeof(((fcio_config){0}).gps);
+  total_size += frame_header + sizeof(*((fcio_config){0}).tracemap) * (config->adcs+config->triggers);
+  return total_size;
+}
+
+static inline size_t status_size(const fcio_status* status)
+{
+  const size_t frame_header = sizeof(int);
+  size_t total_size = 0;
+
+  total_size += frame_header; // tag_size
+  total_size += frame_header + sizeof(((fcio_status){0}).status);
+  total_size += frame_header + sizeof(*((fcio_status){0}).statustime) * 10;
+  total_size += frame_header + sizeof(((fcio_status){0}).cards);
+  total_size += frame_header + sizeof(((fcio_status){0}).size);
+  total_size += (frame_header + status->size) * status->cards;
+  return total_size;
+}
+
+
+FCIORecordSizes FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes sizes)
+{
+  const size_t frame_header = sizeof(int);
+
+  sizes.protocol = TMIO_PROTOCOL_SIZE + frame_header;
+  sizes.config = config_size(&data->config);
+  sizes.event = event_size(FCIOEvent, &data->event, &data->config);
+  sizes.status = status_size(&data->status);
+  sizes.eventheader = event_size(FCIOEventHeader, &data->event, &data->config);
+  sizes.sparseevent = event_size(FCIOSparseEvent, &data->event, &data->config);
+
+  return sizes;
+}

--- a/src/fcio_utils.c
+++ b/src/fcio_utils.c
@@ -24,6 +24,18 @@ size_t FCIOWrittenBytes(FCIOStream stream)
   return new;
 }
 
+size_t FCIOReadBytes(FCIOStream stream)
+{
+  static size_t read = 0;
+  if (!stream)
+    return read = 0;
+  tmio_stream* tmio = (tmio_stream*)stream;
+
+  size_t new = tmio->bytesread - read;
+  read = tmio->byteswritten;
+  return new;
+}
+
 void FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes* sizes)
 {
   if (!data || !sizes)

--- a/src/fcio_utils.h
+++ b/src/fcio_utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "fcio.h"
+
+typedef struct {
+  size_t protocol;
+  size_t config;
+  size_t event;
+  size_t sparseevent;
+  size_t eventheader;
+  size_t status;
+  size_t fspconfig;
+  size_t fspevent;
+  size_t fspstatus;
+
+} FCIORecordSizes;
+
+FCIORecordSizes FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes sizes);
+FCIORecordSizes FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes sizes);

--- a/src/fcio_utils.h
+++ b/src/fcio_utils.h
@@ -21,3 +21,4 @@ void FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
 void FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
 size_t FCIOWrittenBytes(FCIOStream stream);
 int FCIOSetMemField(FCIOStream stream, char *mem_addr, size_t mem_size);
+const char* FCIOTagStr(int tag);

--- a/src/fcio_utils.h
+++ b/src/fcio_utils.h
@@ -17,5 +17,6 @@ typedef struct {
 
 } FCIORecordSizes;
 
-FCIORecordSizes FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes sizes);
-FCIORecordSizes FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes sizes);
+void FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
+void FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
+size_t FCIOWrittenBytes(FCIOStream stream);

--- a/src/fcio_utils.h
+++ b/src/fcio_utils.h
@@ -28,3 +28,4 @@ size_t FCIOStreamBytes(FCIOStream stream, int direction, size_t offset);
 
 int FCIOSetMemField(FCIOStream stream, void *mem_addr, size_t mem_size);
 void FCIOPrintRecordSizes(FCIORecordSizes sizes);
+const char* FCIOTagStr(int tag);

--- a/src/fcio_utils.h
+++ b/src/fcio_utils.h
@@ -20,3 +20,4 @@ typedef struct {
 void FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
 void FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
 size_t FCIOWrittenBytes(FCIOStream stream);
+int FCIOSetMemField(FCIOStream stream, char *mem_addr, size_t mem_size);

--- a/src/fcio_utils.h
+++ b/src/fcio_utils.h
@@ -19,6 +19,12 @@ typedef struct {
 
 void FCIOMeasureRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
 void FCIOCalculateRecordSizes(FCIOData* data, FCIORecordSizes* sizes);
+
+void FCIOStateMeasureRecordSizes(FCIOState* state, FCIORecordSizes* sizes);
+void FCIOStateCalculateRecordSizes(FCIOState* state, FCIORecordSizes* sizes);
+
 size_t FCIOWrittenBytes(FCIOStream stream);
-int FCIOSetMemField(FCIOStream stream, char *mem_addr, size_t mem_size);
-const char* FCIOTagStr(int tag);
+size_t FCIOStreamBytes(FCIOStream stream, int direction, size_t offset);
+
+int FCIOSetMemField(FCIOStream stream, void *mem_addr, size_t mem_size);
+void FCIOPrintRecordSizes(FCIORecordSizes sizes);

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,9 +1,21 @@
-install_headers('fcio.h')
-fcio_sources =files('fcio.c', 'time_utils.c')
+fcio_inc = include_directories('.')
 
+install_headers('fcio.h')
+fcio_sources = files('fcio.c', 'time_utils.c')
 fcio_lib = library('fcio',
   fcio_sources,
   include_directories : fcio_inc,
   dependencies : [ tmio_dep ],
   install : true
 )
+fcio_dep = declare_dependency(include_directories : fcio_inc, link_with : fcio_lib, sources : fcio_sources, dependencies : [tmio_dep])
+
+install_headers('fcio_utils.h')
+fcio_utils_sources = files('fcio_utils.c')
+fcio_utils_lib = library('fcio_utils',
+  fcio_utils_sources,
+  include_directories : fcio_inc,
+  dependencies : [ fcio_dep ],
+  install : true
+)
+fcio_utils_dep = declare_dependency(include_directories : fcio_inc, link_with : fcio_utils_lib, sources : fcio_utils_sources, dependencies : [fcio_dep])

--- a/tests/fcio_test_record_sizes.c
+++ b/tests/fcio_test_record_sizes.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "fcio.h"
+#include "fcio_utils.h"
+
+#include "test.h"
+
+void print_sizes(FCIORecordSizes sizes)
+{
+  fprintf(stderr, "..protocol    %zu bytes\n", sizes.protocol);
+  fprintf(stderr, "..config      %zu bytes\n", sizes.config);
+  fprintf(stderr, "..event       %zu bytes\n", sizes.event);
+  fprintf(stderr, "..sparseevent %zu bytes\n", sizes.sparseevent);
+  fprintf(stderr, "..eventheader %zu bytes\n", sizes.eventheader);
+  fprintf(stderr, "..status      %zu bytes\n", sizes.status);
+  fprintf(stderr, "..fspconfig   %zu bytes\n", sizes.fspconfig);
+  fprintf(stderr, "..fspevent    %zu bytes\n", sizes.fspevent);
+  fprintf(stderr, "..fspstatus   %zu bytes\n", sizes.fspstatus);
+}
+
+
+void set_parameters(FCIOData* data, unsigned int nchannels, unsigned int nsamples, int verbose)
+{
+  data->config.adcs = nchannels;
+  data->config.adccards = data->config.adcs / 24 + ((data->config.adcs % 24) == 0 ? 0 : 1);
+  data->config.triggercards = data->config.adccards / 8 + ((data->config.adccards % 8) == 0 ? 0 : 1);
+  data->config.triggers = data->config.triggercards * 8;
+  data->config.mastercards = 1;
+  data->config.eventsamples = nsamples;
+
+  data->event.timestamp_size = 10;
+  data->event.timeoffset_size = 10;
+  data->event.deadregion_size = 10;
+  data->event.num_traces = data->config.adcs + data->config.triggers;
+
+  data->status.cards = data->config.adccards + data->config.triggercards + data->config.mastercards;
+  data->status.size = sizeof(card_status);
+  if (verbose) {
+    fprintf(stderr,
+      "set_parameters:\n"
+      "config: eventsamples %d adcs %d triggers %d\n"
+      "config: adccards %d triggercards %d mastercard %d\n"
+      "event:  num_traces %d\n"
+      "status: cards %d size %d\n"
+      ,data->config.eventsamples, data->config.adcs, data->config.triggers,
+      data->config.adccards, data->config.triggercards, data->config.mastercards,
+      data->event.num_traces, data->status.cards, data->status.size
+    );
+  }
+}
+
+void check(FCIOData* data, unsigned int nchannels, unsigned int nsamples, int verbose) {
+
+  set_parameters(data, nchannels, nsamples, verbose);
+  FCIORecordSizes measured_sizes = {0};
+  FCIORecordSizes calculated_sizes = {0};
+  FCIOMeasureRecordSizes(data, &measured_sizes);
+  FCIOCalculateRecordSizes(data, &calculated_sizes);
+
+  if (verbose) {
+    fprintf(stderr, "measured:\n");
+    print_sizes(measured_sizes);
+    fprintf(stderr, "calculated:\n");
+    print_sizes(calculated_sizes);
+    fprintf(stderr, "\n");
+  }
+
+  assert(measured_sizes.protocol == calculated_sizes.protocol);
+  assert(measured_sizes.config == calculated_sizes.config);
+  assert(measured_sizes.event == calculated_sizes.event);
+  assert(measured_sizes.sparseevent == calculated_sizes.sparseevent);
+  assert(measured_sizes.eventheader == calculated_sizes.eventheader);
+  assert(measured_sizes.status == calculated_sizes.status);
+}
+
+int main(int argc, char* argv[])
+{
+  int verbose = 0;
+  if (argc >= 2)
+    verbose = atoi(argv[1]);
+
+  FCIOData* data = calloc(1, sizeof(FCIOData));
+
+  check(data, 1, 2, verbose); // min
+
+  check(data, 1764, 128, verbose); // fc camera default
+  check(data, 1764, 4096, verbose); // fc camera max
+  check(data, 2304, 8192, verbose); // max 12-bit
+
+  check(data, 181, 8192, verbose); // lgnd
+  check(data, 181, 6144, verbose); // lgnd better
+  check(data, 181, 32768, verbose); // lgnd fft
+  check(data, 576, FCIOMaxSamples, verbose); // max 16-bit
+
+  free(data);
+
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,5 @@
 fcio_test_unknown_tags = executable('fcio_test_unknown_tags', 'fcio_test_unknown_tags.c', dependencies : [fcio_dep])
-fcio_benchmark = executable('fcio_benchmark', ['fcio_benchmark.c', 'timer.c'], dependencies: [fcio_dep])
+fcio_benchmark = executable('fcio_benchmark', ['fcio_benchmark.c', 'timer.c'], dependencies: [fcio_utils_dep])
 fcio_test_record_consistency = executable('fcio_test_record_consistency', 'fcio_test_record_consistency.c', dependencies : [fcio_dep])
 
 test('fcio_test_unknown_tags', fcio_test_unknown_tags, is_parallel : true, args : ['fcio_test_unknown_tags.dat'])
@@ -11,3 +11,5 @@ test('fcio_benchmark_camera_file', fcio_benchmark, is_parallel : false, args : [
 test('fcio_benchmark_germanium_tcp_loopback', fcio_benchmark, is_parallel : false, args : ['-n','10000','-s','8192','-c','180', '-w', 'tcp://listen/3001', '-r', 'tcp://connect/3001/localhost'], suite : ['benchmark'])
 test('fcio_benchmark_germanium_file', fcio_benchmark, is_parallel : false, args : ['-n','1000','-s','8192','-c','180', '-w', 'file://fcio_benchmark.dat', '-r', 'file://fcio_benchmark.dat', '--no-fork'], suite : ['benchmark'])
 
+fcio_test_record_sizes = executable('fcio_test_record_sizes', 'fcio_test_record_sizes.c', dependencies : [fcio_utils_dep])
+test('fcio_test_record_sizes', fcio_test_record_sizes, is_parallel : true, args : ['0'])


### PR DESCRIPTION
This PR adds `fcio_utils` as a dependent library.

So far it contains functions determining the sizes of known records:
`Measure` by writing to `/dev/null`
`Calculate` by using the header definitions.
A test is added to check for same results. 

The `fcio_benchmark` test has been updated to use the calculated sizes.